### PR TITLE
add count patch api

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,13 +1,23 @@
 import axios from 'axios';
 
-const apiUrl = 'https://port-0-popdcu-back-test-3yl7k2blopd9kw1.sel5.cloudtype.app/api';
+const API_URL = 'https://port-0-popdcu-back-test-3yl7k2blopd9kw1.sel5.cloudtype.app/api';
 
 export const getCollegeList = async () => {
   try {
-    const response = await axios.get(`${apiUrl}/ranking`);
+    const response = await axios.get(`${API_URL}/ranking`);
     return response.data;
   } catch (error) {
     console.error('Error fetching ranking data:', error);
+    throw error; // 에러를 상위 컴포넌트로 전파
+  }
+};
+export const updateCount = async (collegeName, updateCounter) => {
+  try {
+    const response = await axios.patch(`${API_URL}/count/name/${collegeName}`, { countNumber: updateCounter, });
+    console.log(response.data); // 서버에서 반환한 데이터
+    return response.data;
+  } catch (error) {
+    console.error('Error updating count:', error);
     throw error; // 에러를 상위 컴포넌트로 전파
   }
 };

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -32,9 +32,13 @@
 </template>
 
 <script>
+import { updateCount } from '@/api.js';
 
 export default {
   name : 'main_component',
+  mounted() {
+    this.intervalId = setInterval(this.handleUpdateCount, 5000);
+  },
 
   data() {
     return {
@@ -80,7 +84,22 @@ export default {
     window.removeEventListener('keydown', this.handleKeyDown);
     window.removeEventListener('keyup', this.handleKeyUp);
   },
+  beforeDestroy() {
+    clearInterval(this.intervalId);
+  },
   methods: {
+    async handleUpdateCount() {
+      const collegeName = localStorage.getItem('UserCollege'); // 실제 값으로 대체
+      const updateCounter = this.$store.state.updateCounter;
+
+      try {
+        await updateCount(collegeName, updateCounter);
+        this.$store.state.updateCounter = 0
+      } catch (error) {
+        console.error('Error in handleUpdateCount:', error);
+      }
+    },
+
     adjustImageSize() {
       // 화면 너비에 따라 이미지 높이를 동적으로 조정
       if (window.innerWidth < 768) {  // 모바일 화면 크기 (예: 768px)로 조정

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 export default new Vuex.Store({
   state: {
     clickedOrKeyedCount: JSON.parse(localStorage.getItem('clickedOrKeyedCount')) || 0,
+    updateCounter: 0,
     mouseClicked: false,
     keyPressed: false,
   },
@@ -15,7 +16,9 @@ export default new Vuex.Store({
     },
     incrementClickedOrKeyedCount(state) {
       state.clickedOrKeyedCount++;
+      state.updateCounter++;
       localStorage.setItem('clickedOrKeyedCount', state.clickedOrKeyedCount);
+      console.log(state.updateCounter)
     },
     setClickedOrKeyedCount(state, value) {
         state.clickedOrKeyedCount = value;


### PR DESCRIPTION
단과대별 카운팅 기능

Flow

단과대를 선택한 클라이언트가 5초에 한번씩 카운팅 횟수를 서버로 전달.

서버에서는 DB에 저장되어 있는 단과대별 카운팅 총합을 누적합 함


https://github.com/POPDCU/POPDCU_Front/assets/43005678/4001adf4-be81-44f8-bcd3-799fddfc1ef4

